### PR TITLE
Add ARM64 support

### DIFF
--- a/ffbinaries-lib.js
+++ b/ffbinaries-lib.js
@@ -61,6 +61,10 @@ function resolvePlatform(input) {
       rtn = 'linux-armhf';
       break;
 
+    case 'linux-arm64':
+      rtn = 'linux-arm64';
+      break;
+
     case 'win':
     case 'win-32':
     case 'windows':
@@ -99,9 +103,8 @@ function detectPlatform(osinfo) {
   }
 
   if (type === 'linux') {
-    if (arch === 'arm' || arch === 'arm64') {
-      return 'linux-armel';
-    }
+    if (arch === 'arm') return 'linux-armel';
+    if (arch === 'arm64') return 'linux-arm64';
     return arch === 'x64' ? 'linux-64' : 'linux-32';
   }
 
@@ -122,7 +125,7 @@ function getBinaryFilename(component, platform) {
 }
 
 function listPlatforms() {
-  return ['osx-64', 'linux-32', 'linux-64', 'linux-armel', 'linux-armhf', 'windows-32', 'windows-64'];
+  return ['osx-64', 'linux-32', 'linux-64', 'linux-armel', 'linux-armhf', 'linux-arm64', 'windows-32', 'windows-64'];
 }
 
 function listVersions(callback) {

--- a/test/ffbinaries-lib.js
+++ b/test/ffbinaries-lib.js
@@ -60,6 +60,12 @@ describe('ffbinaries library', function () {
       var platform = ffbinaries.detectPlatform(osinfo);
       expect(platform).to.equal('linux-armel');
     });
+
+    it('should detect Linux (ARM64)', function () {
+      var osinfo = { type: 'linux', arch: 'arm64' };
+      var platform = ffbinaries.detectPlatform(osinfo);
+      expect(platform).to.equal('linux-arm64');
+    });
   });
 
   describe('resolvePlatform', function () {
@@ -80,6 +86,7 @@ describe('ffbinaries library', function () {
         'linux-arm': 'linux-armel',
         'linux-armel': 'linux-armel',
         'linux-armhf': 'linux-armhf',
+        'linux-arm64': 'linux-arm64',
         'win': 'windows-32',
         'win-32': 'windows-32',
         'windows': 'windows-32',
@@ -119,10 +126,10 @@ describe('ffbinaries library', function () {
   });
 
   describe('listPlatforms', function () {
-    it('should return 7 platforms in an array', function () {
+    it('should return 8 platforms in an array', function () {
       var platforms = ffbinaries.listPlatforms();
       expect(Array.isArray(platforms)).to.equal(true);
-      expect(platforms.length).to.equal(7);
+      expect(platforms.length).to.equal(8);
     });
   });
 


### PR DESCRIPTION
The main https://ffbinaries.com website has ARM64 binaries, but this Node package still tries to use the regular ARM32/armel/armhf binaries on an ARM64 platform.